### PR TITLE
修复外部设置MPILabel.accessibilityLabel不生效的问题

### DIFF
--- a/Sources/MPILabel.m
+++ b/Sources/MPILabel.m
@@ -350,11 +350,11 @@ static NSString *const kAsyncFadeAnimationKey = @"contents";
 #pragma mark - UIAccessibility
 
 - (NSString *)accessibilityLabel {
-    return self.text;
+    return [super accessibilityLabel] ? : self.text;
 }
 
 - (NSAttributedString *)accessibilityAttributedLabel {
-    return self.attributedText;
+    return [super accessibilityAttributedLabel] ? : self.attributedText;
 }
 
 #pragma mark - UIResponderStandardEditActions


### PR DESCRIPTION
修复外部设置MPILabel.accessibilityLabel不生效的问题，见：https://github.com/meitu/MPITextKit/issues/33